### PR TITLE
Use status code 401 for ErrNotAuthorized

### DIFF
--- a/web/app/context.go
+++ b/web/app/context.go
@@ -52,6 +52,8 @@ func (c *Context) Error(err error) {
 		c.RespondError(err.Error(), http.StatusBadRequest)
 	case ErrValidation:
 		c.RespondError(err.Error(), http.StatusBadRequest)
+	case ErrNotAuthorized:
+		c.RespondError(err.Error(), http.StatusUnauthorized)
 	default:
 		c.RespondError(err.Error(), http.StatusInternalServerError)
 	}


### PR DESCRIPTION
I'm working on a project using kit and I noticed when a user fails to authenticate that we respond with an Internal Server Error.

I couldn't see if there were existing tests where it would be appropriate to assert this new behavior so I didn't add any. It didn't seem to break any of the existing tests.