### PR TITLE
Add FixedTime middleware

### DIFF
--- a/web/app/README.md
+++ b/web/app/README.md
@@ -110,6 +110,7 @@ pair, this makes for really easy, convenient routing.
 type Context struct {
     http.ResponseWriter
     Request   *http.Request
+    Now       time.Time
     Params    map[string]string
     SessionID string
     Status    int

--- a/web/midware/README.md
+++ b/web/midware/README.md
@@ -14,6 +14,14 @@ func Auth(h app.Handler) app.Handler
 Auth handles token authentication.
 
 
+## func FixedTime
+``` go
+func FixedTime(now time.Time) func(h app.Handler) app.Handler
+```
+FixedTime is useful when testing time dependent APIs as it sets the Now
+property of all Contexts to a fixed time.
+
+
 ## func Mongo
 ``` go
 func Mongo(h app.Handler) app.Handler

--- a/web/midware/fixedtime.go
+++ b/web/midware/fixedtime.go
@@ -1,0 +1,21 @@
+package midware
+
+import (
+	"time"
+
+	"github.com/ardanlabs/kit/log"
+	"github.com/ardanlabs/kit/web/app"
+)
+
+// FixedTime is useful when testing time dependent APIs as it sets the Now
+// property of all Contexts to a fixed time.
+func FixedTime(now time.Time) func(h app.Handler) app.Handler {
+	return func(h app.Handler) app.Handler {
+		return func(c *app.Context) error {
+			log.Dev(c.SessionID, "FixedTime", "Setting context time to fixed time %v", now)
+			c.Now = now
+
+			return h(c)
+		}
+	}
+}

--- a/web/midware/fixedtime_test.go
+++ b/web/midware/fixedtime_test.go
@@ -1,0 +1,57 @@
+package midware_test
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ardanlabs/kit/tests"
+	"github.com/ardanlabs/kit/web/app"
+	"github.com/ardanlabs/kit/web/midware"
+)
+
+func init() {
+	tests.Init("KIT")
+}
+
+// Success and failure markers.
+var (
+	success = "\u2713"
+	failed  = "\u2717"
+)
+
+//==============================================================================
+
+// TestFixedTime ensures that a context going through the FixedTime middleware
+// gets its Now time set to a fixed point.
+func TestFixedTime(t *testing.T) {
+	tests.ResetLog()
+	defer tests.DisplayLog()
+
+	t.Log("Given the need to set a fixed time on requests we handle")
+	{
+		expected := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+		a := app.New(midware.FixedTime(expected))
+
+		var actual time.Time
+		a.Handle("GET", "/", func(c *app.Context) error {
+			actual = c.Now
+			return nil
+		})
+
+		w := httptest.NewRecorder()
+		r := tests.NewRequest("GET", "/", nil)
+
+		a.ServeHTTP(w, r)
+
+		t.Log("\tWhen a request is made using the middleware.")
+		{
+			if actual.Equal(expected) {
+				t.Logf("\t\t%s Context.Now should be set to the expected time %v", success, actual)
+			} else {
+				t.Errorf("\t\t%s Context.Now should be set to the expected time %v", failed, actual)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This middleware can be enabled during testing which helps for testing time dependent APIs.

This is how I'd use it

```go
// API returns a handler for all of the API routes
func API(testing ...bool) http.Handler {
	// Enable middleware to init mongodb and auth
	a := app.New(midware.Mongo, midware.Auth)
	// During testing we add another middleware to fix the time of each request
	if testing != nil {
		a = app.New(
			midware.Mongo,
			midware.Auth,
			midware.FixedTime(time.Date(2016, time.February, 16, 10, 0, 0, 0, time.UTC)),
		)
	}

	routes(a)

	return a
}
```