### PR TITLE
Testfix

### DIFF
--- a/tests/tests.go
+++ b/tests/tests.go
@@ -58,7 +58,7 @@ func Init(cfgKey string) {
 		}
 		return ll
 	}
-	log.Init(&logdash, logLevel)
+	log.Init(&logdash, logLevel, log.Ldefault)
 }
 
 // InitMongo initializes the mongodb connections for testing.


### PR DESCRIPTION
We forgot to update the tests package with the change to the log.Init function, this merge will add the Ldefault flag as the third argument.