### PR TITLE
Log error when json.Marshal fails

### DIFF
--- a/web/app/context.go
+++ b/web/app/context.go
@@ -68,7 +68,7 @@ func (c *Context) Respond(data interface{}, code int) {
 	// Load any user defined header values.
 	if app.userHeaders != nil {
 		for key, value := range app.userHeaders {
-			log.User("startup", "Init", "Setting user headers : %s:%s", key, value)
+			log.User("startup", "api : Respond", "Setting user headers : %s:%s", key, value)
 			c.Header().Set(key, value)
 		}
 	}
@@ -88,6 +88,7 @@ func (c *Context) Respond(data interface{}, code int) {
 	// Marshal the data into a JSON string.
 	jsonData, err := json.Marshal(data)
 	if err != nil {
+		log.Error(c.SessionID, "api : Respond", err, "Marshalling JSON response")
 		jsonData = []byte("{}")
 	}
 


### PR DESCRIPTION
`(*Context).Respond` was silently eating errors encountered when marshalling a JSON response. It took me a while to figure out why this was dying. I added a log call so I can at least know when it fails. I'm not sure if we'd want to do anything else.

Also I fixed an unrelated log message for consistency.