### PR TITLE
Changed Marshal to MarshalIndent

### DIFF
--- a/web/app/context.go
+++ b/web/app/context.go
@@ -87,7 +87,7 @@ func (c *Context) Respond(data interface{}, code int) {
 	c.WriteHeader(code)
 
 	// Marshal the data into a JSON string.
-	jsonData, err := json.Marshal(data)
+	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		log.Error(c.SessionID, "api : Respond", err, "Marshalling JSON response")
 		jsonData = []byte("{}")


### PR DESCRIPTION
Responding with indented JSON aids in development and consumption of the API and does not add that much extra data to transmit.

Ref: http://www.vinaysahni.com/best-practices-for-a-pragmatic-restful-api#pretty-print-gzip