### PR TITLE
Rewrote the server's error handling

### DIFF
--- a/examples/web/main.go
+++ b/examples/web/main.go
@@ -7,11 +7,14 @@ import (
 	"time"
 
 	"github.com/ardanlabs/kit/examples/web/routes"
+	"github.com/ardanlabs/kit/log"
 	"github.com/ardanlabs/kit/web/app"
 )
 
 func main() {
 	// Look at /kit/config for a set of possible config settings.
 
-	app.Run(":4000", routes.API(), 10*time.Second, 10*time.Second)
+	err := app.Run(":4000", routes.API(), 10*time.Second, 10*time.Second)
+
+	log.User("main", "main", "DOWN: %v", err)
 }

--- a/web/app/app.go
+++ b/web/app/app.go
@@ -231,8 +231,8 @@ func Run(defaultHost string, routes http.Handler, readTimeout, writeTimeout time
 			if err != nil {
 				log.Fatal("shutdown", "Run", "Error Occured: %s", err.Error())
 			}
-		case s := <-osSignals:
-			log.User("shutdown", "Run", "Captured %v. Exiting...", s)
+		case sig := <-osSignals:
+			log.User("shutdown", "Run", "Captured %v. Exiting...", sig)
 
 			// Shut down the API server.
 			server.BlockingClose()


### PR DESCRIPTION
We are using the github.com/braintree/manners server for our web server, yet weren't using the features! Also we weren't capturing the errors related to starting the server (like binding to a port that's already in use). This resolves those issues.