### PR TITLE
Adjusted mongo config to use uri format

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ardanlabs/kit/auth"
 	"github.com/ardanlabs/kit/auth/session"
 	"github.com/ardanlabs/kit/db"
-	"github.com/ardanlabs/kit/db/mongo"
 	"github.com/ardanlabs/kit/tests"
 
 	"gopkg.in/mgo.v2"
@@ -21,7 +20,7 @@ func init() {
 	os.Setenv("KIT_LOGGING_LEVEL", "1")
 
 	tests.Init("KIT")
-	tests.InitMongo(mongo.Config{})
+	tests.InitMongo("")
 
 	ensureIndexes()
 }

--- a/auth/session/session_test.go
+++ b/auth/session/session_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ardanlabs/kit/auth/session"
 	"github.com/ardanlabs/kit/db"
-	"github.com/ardanlabs/kit/db/mongo"
 	"github.com/ardanlabs/kit/tests"
 
 	"gopkg.in/mgo.v2"
@@ -21,7 +20,7 @@ func init() {
 	os.Setenv("KIT_LOGGING_LEVEL", "1")
 
 	tests.Init("KIT")
-	tests.InitMongo(mongo.Config{})
+	tests.InitMongo("")
 
 	ensureIndexes()
 }

--- a/db/cayley.go
+++ b/db/cayley.go
@@ -15,8 +15,8 @@ var ErrGraphHandle = errors.New("Graph handle not initialized.")
 
 // OpenCayley opens a connection to Cayley and adds that support to the
 // database value.
-func (db *DB) OpenCayley(context interface{}, cfg kitcayley.Config) error {
-	store, err := kitcayley.New(cfg)
+func (db *DB) OpenCayley(context interface{}, mongoURL string) error {
+	store, err := kitcayley.New(mongoURL)
 	if err != nil {
 		return err
 	}

--- a/db/cayley/cayley.go
+++ b/db/cayley/cayley.go
@@ -15,7 +15,6 @@ import (
 
 // New creates a new cayley handle.
 func New(mongoURL string) (*cayley.Handle, error) {
-
 	cfg, err := url.Parse(mongoURL)
 	if err != nil {
 		return nil, err

--- a/db/mongo.go
+++ b/db/mongo.go
@@ -77,8 +77,9 @@ func NewMGO(context interface{}, name string) (*DB, error) {
 
 	ses := db.ses.Copy()
 
-	// As per the mgo documentation, if no database name is specified, then use
-	// the default one, or the one that the connection was dialed with.
+	// As per the mgo documentation, https://godoc.org/gopkg.in/mgo.v2#Session.DB
+	// if no database name is specified, then use the default one, or the one that
+	// the connection was dialed with.
 	mdb := ses.DB("")
 
 	dbOut := DB{

--- a/db/mongo/mongo.go
+++ b/db/mongo/mongo.go
@@ -3,48 +3,26 @@ package mongo
 
 import (
 	"encoding/json"
-	"strings"
 	"time"
 
 	"gopkg.in/mgo.v2"
 )
 
-// Config provides configuration values.
-type Config struct {
-	Host     string
-	AuthDB   string
-	DB       string
-	User     string
-	Password string
-	Timeout  time.Duration
-}
-
 //==============================================================================
 
-// New creates a new master session.
-func New(cfg Config) (*mgo.Session, error) {
-
-	// Can be provided a comma delimited set of hosts.
-	hosts := strings.Split(cfg.Host, ",")
+// New creates a new master session. If no url is provided, it will defaul to
+// localhost:27017. If a zero value timeout is specified, a timeout of 60sec
+// will be used instead.
+func New(url string, timeout time.Duration) (*mgo.Session, error) {
 
 	// Set the default timeout for the session.
-	timeout := cfg.Timeout
 	if timeout == 0 {
 		timeout = 60 * time.Second
 	}
 
-	// We need this object to establish a session to our MongoDB.
-	mongoDBDialInfo := mgo.DialInfo{
-		Addrs:    hosts,
-		Timeout:  timeout,
-		Database: cfg.AuthDB,
-		Username: cfg.User,
-		Password: cfg.Password,
-	}
-
 	// Create a session which maintains a pool of socket connections
 	// to our MongoDB.
-	ses, err := mgo.DialWithInfo(&mongoDBDialInfo)
+	ses, err := mgo.DialWithTimeout(url, timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ardanlabs/kit/cfg"
 	"github.com/ardanlabs/kit/db"
-	"github.com/ardanlabs/kit/db/mongo"
 	"github.com/ardanlabs/kit/log"
 )
 
@@ -62,9 +61,10 @@ func Init(cfgKey string) {
 	log.Init(&logdash, logLevel, log.Ldefault)
 }
 
-// InitMongo initializes the mongodb connections for testing.
-func InitMongo(cfg mongo.Config) {
-	if err := db.RegMasterSession("Test", TestSession, cfg); err != nil {
+// InitMongo initializes the mongodb connections for testing. If no url is
+// provided it will default to localhost:27017.
+func InitMongo(url string) {
+	if err := db.RegMasterSession("Test", TestSession, url, 0); err != nil {
 		log.Error("Test", "Init", err, "Completed")
 		logdash.WriteTo(os.Stdout)
 		os.Exit(1)


### PR DESCRIPTION
This PR is designed to migrate over the configuration details from an explicit config struct to a uri format documented here: https://docs.mongodb.com/manual/reference/connection-string/

This is already supported by the underlying driver (mgo).