### PR TITLE
Fix a server startup bug

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -173,7 +173,6 @@ func Run(host string, routes http.Handler, readTimeout, writeTimeout time.Durati
 
 	// We want to use an error channel to block and receive the error.
 	serverErrors := make(chan error, 1)
-	defer close(serverErrors)
 
 	// Start the listener.
 	go func() {

--- a/web/web.go
+++ b/web/web.go
@@ -189,6 +189,7 @@ func Run(host string, routes http.Handler, readTimeout, writeTimeout time.Durati
 	select {
 	case <-done:
 	case <-osSignals:
+
 		// Create a context to attempt a graceful 5 second shutdown.
 		const timeout = 5 * time.Second
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -206,7 +207,7 @@ func Run(host string, routes http.Handler, readTimeout, writeTimeout time.Durati
 	}
 
 	// Wait for the listener to report it is closed.
-	// A closed channel never blocks
+	// A closed channel never blocks.
 	<-done
 	return err
 }


### PR DESCRIPTION
If `server.ListenAndServe()` cannot startup due to errors such as "port in use", it return an error and get stuck waiting for `osSignals`. This is not ideal because if a server doesn't start, we don't want to be waiting for an exit signal from the OS. We want to log the error and exit.

Unfortunately, we can't select on a waitgroup. This PR adds a channel and select statement to handle the above case.